### PR TITLE
Issue_25

### DIFF
--- a/src/AbTesting.php
+++ b/src/AbTesting.php
@@ -125,8 +125,11 @@ class AbTesting
     public function isExperiment(string $name)
     {
         $this->pageView();
-
-        return $this->getExperiment()->name === $name;
+        $experiment = $this->getExperiment();
+        if ($experiment === null){
+            return false;
+        }
+        return $experiment->name === $name;
     }
 
     /**
@@ -142,7 +145,12 @@ class AbTesting
             $this->pageView();
         }
 
-        $goal = $this->getExperiment()->goals->where('name', $goal)->first();
+        $experiment = $this->getExperiment();
+        if ($experiment === null){
+            return false;
+        }
+
+        $goal = $experiment->goals->where('name', $goal)->first();
 
         if (! $goal) {
             return false;


### PR DESCRIPTION
If the session variables don't exist isExperiment throws Trying to get property 'name' of non-object.

This can happen under dusk testing or a crawler.

This fix is just to have isExperiment return False if the experiment is not found rather than assuming Name will always exist.

Same issue in completeGoal fixed